### PR TITLE
Should close ReadOnlyTransaction when is no longer needed

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -154,6 +154,7 @@ func (d *Dumper) DumpTables(ctx context.Context) error {
 	if d.timestamp != nil {
 		txn = txn.WithTimestampBound(spanner.ReadTimestamp(*d.timestamp))
 	}
+	defer txn.Close()
 
 	iter, err := FetchTables(ctx, txn)
 	if err != nil {


### PR DESCRIPTION
We should close ReadOnlyTransaction when is no longer needed to release resources on the server.