### PR TITLE
Adding a options flag to allow you to not dump any data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Application Options:
   -d, --database=  (required) Cloud Spanner Database ID.
       --tables=    comma-separated table names, e.g. "table1,table2"
       --no-ddl     No DDL information.
-      --no-data    No data dump
+      --no-data    Do not dump data.
       --timestamp= Timestamp for database snapshot in the RFC 3339 format.
       --bulk-size= Bulk size for values in a single INSERT statement.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Please feel free to report issues and send pull requests, but note that this app
 
 This tool can be used for the following use cases.
 
-- Export a database in text format for testing purposes
+- Export a database schema and/or data in text format for testing purposes
 - Export a database running on [Cloud Spanner Emulator](https://cloud.google.com/spanner/docs/emulator)
 
 For production databases, you should use an [officially-provided export](https://cloud.google.com/spanner/docs/export),
@@ -48,6 +48,7 @@ Application Options:
   -d, --database=  (required) Cloud Spanner Database ID.
       --tables=    comma-separated table names, e.g. "table1,table2"
       --no-ddl     No DDL information.
+      --no-data    No data dump
       --timestamp= Timestamp for database snapshot in the RFC 3339 format.
       --bulk-size= Bulk size for values in a single INSERT statement.
 

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ type options struct {
 	DatabaseId string `short:"d" long:"database" description:"(required) Cloud Spanner Database ID."`
 	Tables     string `long:"tables" description:"comma-separated table names, e.g. \"table1,table2\" "`
 	NoDDL      bool   `long:"no-ddl" description:"No DDL information."`
-	NoData     bool   `long:"no-data" description: "No data dump."`
+	NoData      bool   `long:"no-data" description:"Do not dump data."`
 	Timestamp  string `long:"timestamp" description:"Timestamp for database snapshot in the RFC 3339 format."`
 	BulkSize   uint   `long:"bulk-size" description:"Bulk size for values in a single INSERT statement."`
 }

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ type options struct {
 	DatabaseId string `short:"d" long:"database" description:"(required) Cloud Spanner Database ID."`
 	Tables     string `long:"tables" description:"comma-separated table names, e.g. \"table1,table2\" "`
 	NoDDL      bool   `long:"no-ddl" description:"No DDL information."`
+	NoData     bool   `long:"no-data" description: "No data dump."`
 	Timestamp  string `long:"timestamp" description:"Timestamp for database snapshot in the RFC 3339 format."`
 	BulkSize   uint   `long:"bulk-size" description:"Bulk size for values in a single INSERT statement."`
 }
@@ -75,8 +76,10 @@ func main() {
 		}
 	}
 
-	if err := dumper.DumpTables(ctx); err != nil {
-		exitf("Failed to dump tables: %v\n", err)
+	if !opts.NoData {
+		if err := dumper.DumpTables(ctx); err != nil {
+			exitf("Failed to dump tables: %v\n", err)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ type options struct {
 	DatabaseId string `short:"d" long:"database" description:"(required) Cloud Spanner Database ID."`
 	Tables     string `long:"tables" description:"comma-separated table names, e.g. \"table1,table2\" "`
 	NoDDL      bool   `long:"no-ddl" description:"No DDL information."`
-	NoData      bool   `long:"no-data" description:"Do not dump data."`
+	NoData     bool   `long:"no-data" description:"Do not dump data."`
 	Timestamp  string `long:"timestamp" description:"Timestamp for database snapshot in the RFC 3339 format."`
 	BulkSize   uint   `long:"bulk-size" description:"Bulk size for values in a single INSERT statement."`
 }


### PR DESCRIPTION
By using the `no-data` flag you can easily dump just the DDL.