### PR TITLE
Update decoder.go

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -199,7 +199,7 @@ func nullBytesToString(v []byte) string {
 	sb.WriteString("b") // prefix for bytes literal
 	sb.WriteString(`"`) // quote start
 	for _, b := range v {
-		sb.WriteString(fmt.Sprintf("\\x%x", b))
+		sb.WriteString(fmt.Sprintf("\\x%02x", b))
 	}
 	sb.WriteString(`"`) // quote end
 	return sb.String()

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -92,8 +92,8 @@ func TestDecodeColumn(t *testing.T) {
 		},
 		{
 			desc:  "bytes",
-			value: []byte{'a', 'b', 'c'},
-			want:  `b"\x61\x62\x63"`,
+			value: []byte("abc\x01\xa0"),
+			want:  `b"\x61\x62\x63\x01\xa0"`,
 		},
 		{
 			desc:  "float64",


### PR DESCRIPTION
Make sure hex is 0 padded and at least 2 characters wide.

Currently the binary to hex function can produce an invalid hex code, for example it may write \x1 instead of \x01 and \x1 is not a valid hex escape code. 
Example here: https://play.golang.org/p/lgcm9PyfmG8

