### PR TITLE
Adding options from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ which should be stable and much faster.
 
 ## Limitations
 
-- This tool does not ensure consistency between database schema (DDL) and data. So you should avoid making changes to the schema while you are running this tool. 
+- This tool does not ensure consistency between database schema (DDL) and data. So you should avoid making changes to the schema while you are running this tool.
 - This tool does not consider data order constrained by [Foreign Keys](https://cloud.google.com/spanner/docs/foreign-keys/overview).
 
 ## Install
@@ -43,9 +43,9 @@ Usage:
   spanner-dump [OPTIONS]
 
 Application Options:
-  -p, --project=   (required) GCP Project ID.
-  -i, --instance=  (required) Cloud Spanner Instance ID.
-  -d, --database=  (required) Cloud Spanner Database ID.
+  -p, --project=   (required) GCP Project ID. [$SPANNER_PROJECT_ID]
+  -i, --instance=  (required) Cloud Spanner Instance ID. [$SPANNER_INSTANCE_ID]
+  -d, --database=  (required) Cloud Spanner Database ID. [$SPANNER_DATABASE_ID]
       --tables=    comma-separated table names, e.g. "table1,table2"
       --no-ddl     No DDL information.
       --no-data    Do not dump data.

--- a/main.go
+++ b/main.go
@@ -28,9 +28,9 @@ import (
 )
 
 type options struct {
-	ProjectId  string `short:"p" long:"project" description:"(required) GCP Project ID."`
-	InstanceId string `short:"i" long:"instance" description:"(required) Cloud Spanner Instance ID."`
-	DatabaseId string `short:"d" long:"database" description:"(required) Cloud Spanner Database ID."`
+	ProjectId  string `short:"p" long:"project" env:"SPANNER_PROJECT_ID" description:"(required) GCP Project ID."`
+	InstanceId string `short:"i" long:"instance" env:"SPANNER_INSTANCE_ID" description:"(required) Cloud Spanner Instance ID."`
+	DatabaseId string `short:"d" long:"database" env:"SPANNER_DATABASE_ID" description:"(required) Cloud Spanner Database ID."`
 	Tables     string `long:"tables" description:"comma-separated table names, e.g. \"table1,table2\" "`
 	NoDDL      bool   `long:"no-ddl" description:"No DDL information."`
 	NoData     bool   `long:"no-data" description:"Do not dump data."`


### PR DESCRIPTION
The changeset add support for specifying a subset of options via environment variables:

- `SPANNER_PROJECT_ID` as alternative to `-p` option
- `SPANNER_INSTANCE_ID` as alternative to `-i` option
- `SPANNER_DATABASE_ID` as alternative to `-d` option