### PR TITLE
Use `go install` instead of `go get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ which should be stable and much faster.
 ## Install
 
 ```
-go get -u github.com/cloudspannerecosystem/spanner-dump
+go install github.com/cloudspannerecosystem/spanner-dump@latest
 ```
 
 ## Usage


### PR DESCRIPTION
Update README to use `go install`.
> 'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.